### PR TITLE
Solve bug during mining a local folder with option '-u'

### DIFF
--- a/src/url.c
+++ b/src/url.c
@@ -231,8 +231,21 @@ void url_download(struct minr_job *job)
 	{
 		printf("Capture failed: %s\n",job->tmp_dir);
 	}
-	
-	rm_tmpdir(aux_root_dir);
+
+	/* Delete temp directory which store source package via url downloading*/	
+	if (aux_root_dir != NULL && aux_root_dir[0] == '\0')
+	{
+		// aux_root_dir is NULL string
+	}
+	else if (aux_root_dir == NULL)
+	{
+		// aux_root_dir is NULL pointer
+	}
+	else
+	{
+		rm_tmpdir(aux_root_dir);
+	}
+
 	free(aux_root_dir);
 	/* Close files */
 	for (int i=0; i < 256; i++)


### PR DESCRIPTION
Solve the bug when mining the wfps of local folder into KB with command like: 
`minr -d scanoss,engine,v5.2.4,20230627,GPL-2.0,pkg:github/scanoss/engine -u ~/test_codebase/chatgpt/ChatGPT/`
when run the command, it will meet exceptions like:
![Screenshot from 2023-07-03 16-13-40](https://github.com/scanoss/minr/assets/45934483/65a27124-009e-4ef1-8aec-6bc2175fdbb2)

In fact, '-u' option tell us that it supports url and a local folder to be mined
![Screenshot from 2023-07-03 16-18-40](https://github.com/scanoss/minr/assets/45934483/20de9847-4c90-40cd-bbb4-28541d008813)

'-u' option will go into url_download function, and temp dir which is used to store source code is initialized with NULL `char * aux_root_dir = NULL;` .  It will be assigned with value job->tmp_dir only during url mining process, but the space cleaning operation will be called during url mining and folder mining process.
![Screenshot from 2023-07-03 16-34-03](https://github.com/scanoss/minr/assets/45934483/b966670e-a50a-4189-9dd4-20b0b8f69116)

So it will meet exceptions during local folder mining
`rm -rf (NULL)`