### PR TITLE
[unexpected error] temp solution about data loss during data importation

### DIFF
--- a/src/import.c
+++ b/src/import.c
@@ -622,7 +622,7 @@ bool ldb_import_csv(struct minr_job *job, char *filename, char *table, bool seco
 						ldb_node_write(oss_bulk, item_sector, item_lastid, item_buf, item_ptr, 0);
 				}
 				/* Open new sector if needed */
-				if (*itemid != *item_lastid)
+				if (*itemid != *item_lastid || (*itemid == 0 && !item_ptr))
 				{
 					if (item_sector)
 						fclose(item_sector);


### PR DESCRIPTION
https://github.com/scanoss/ldb/issues/17
The first data in 00.csv will be overwritten by the next data in 00.csv