### PR TITLE
solve bug creating empty .csv file on pivot dir

### DIFF
--- a/inc/minr.h
+++ b/inc/minr.h
@@ -29,7 +29,7 @@
 #include <string.h>
 
 /* Definitions */
-#define MINR_VERSION "2.5.17"
+#define MINR_VERSION "2.5.18"
 #define FILE_FILES 256
 #define MAX_ARG_LEN 1024
 #define MIN_FILE_REC_LEN 70

--- a/src/minr.c
+++ b/src/minr.c
@@ -417,12 +417,6 @@ void mine(struct minr_job *job, char *path)
 				return;
 		}
 
-	//Ignore path with ',' inside
-	if (strchr(path, ','))
-	{
-		minr_log("Ignored due to: comma inside path\n");
-		return;
-	}
 
 	if (unwanted_path(path))
 	{
@@ -444,6 +438,10 @@ void mine(struct minr_job *job, char *path)
 		else
 			extra_table = true;
 	}
+	//Replace comma in path for '-'
+	char * comma = strchr(path, ',');
+	if (comma)
+		*comma = '-';
 
 	/* Add to .mz */
 	if (!job->exclude_mz)

--- a/src/url.c
+++ b/src/url.c
@@ -164,7 +164,7 @@ void url_download(struct minr_job *job)
 	/*Pivot table will have only one file*/
 	char pivot_path[MAX_PATH_LEN];
 	sprintf(pivot_path, "%s/%s/", job->mined_path, TABLE_NAME_PIVOT);
-	if (create_dir(pivot_path))
+	if (create_dir(pivot_path) && *job->urlid)
 	{
 		strncat(pivot_path, job->urlid, 2);
 		strcat(pivot_path, ".csv");


### PR DESCRIPTION
 Do not ignore paths with commas any more, but replace these by "-"